### PR TITLE
Fix duplicates caused by not having a __hash__ method on Python 2 for Tag elements

### DIFF
--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -219,34 +219,35 @@ class Pynliner(object):
             for selector in selectors:
                 elements += select(self.soup, selector)
             # build prop_list for each selected element
-            for elem in elements:
-                if elem not in elem_prop_map:
-                    elem_prop_map[elem] = []
-                elem_prop_map[elem].append({
+            for element in elements:
+                element_tuple = (element, id(element))
+                if element_tuple not in elem_prop_map:
+                    elem_prop_map[element_tuple] = []
+                elem_prop_map[element_tuple].append({
                     'specificity': self._get_rule_specificity(rule),
                     'props': rule.style.getProperties(),
                 })
 
         # build up another property list using selector specificity
-        for elem, props in elem_prop_map.items():
-            if elem not in elem_style_map:
-                elem_style_map[elem] = cssutils.css.CSSStyleDeclaration()
+        for elem_tuple, props in elem_prop_map.items():
+            if elem_tuple not in elem_style_map:
+                elem_style_map[elem_tuple] = cssutils.css.CSSStyleDeclaration()
             # ascending sort of prop_lists based on specificity
             props = sorted(props, key=lambda p: p['specificity'])
             # for each prop_list, apply to CSSStyleDeclaration
             for prop_list in map(lambda obj: obj['props'], props):
                 for prop in prop_list:
-                    elem_style_map[elem].removeProperty(prop.name)
-                    elem_style_map[elem].setProperty(prop.name, prop.value)
-
+                    elem_style_map[elem_tuple].removeProperty(prop.name)
+                    elem_style_map[elem_tuple].setProperty(prop.name, prop.value)
 
         # apply rules to elements
-        for elem, style_declaration in elem_style_map.items():
+        for elem_tuple, style_declaration in elem_style_map.items():
+            elem, elem_id = elem_tuple
             if elem.has_attr('style'):
                 elem['style'] = u'%s; %s' % (style_declaration.cssText.replace('\n', ' '), elem['style'])
             else:
                 elem['style'] = style_declaration.cssText.replace('\n', ' ')
-        
+
     def _get_output(self):
         """Generate Unicode string of `self.soup` and set it to `self.output`
 


### PR DESCRIPTION
This resulted in the style not being applied when multiple elements have same class and same content on Python 3. This was not a problem when we were using `BeautifulSoup 3` because it didn't have a custom `__hash__` implementation, but now on Python 3 on `bs4`, `Tag` elements have a custom `__hash__` resulting in just an instance of that object for certain styles.